### PR TITLE
Use wheel for epicscorelibs_pcas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
     "epicscorelibs", 
-	"swig", 
-	"epicscorelibs_pcas @ git+https://github.com/IsisComputingGroup/epicscorelibs_pcas@main"
+    "swig", 
+    "epicscorelibs_pcas @ https://github.com/ISISComputingGroup/epicscorelibs_pcas/releases/download/v0.0.1/epicscorelibs_pcas-0.0.1a0-cp311-cp311-win_amd64.whl ; python_version == '3.11'"
 ]

--- a/setup.py
+++ b/setup.py
@@ -170,7 +170,7 @@ _version = load_module("_version", "pcaspy/_version.py")
 
 requirements = [
     "epicscorelibs",
-    "epicscorelibs_pcas @ git+https://github.com/IsisComputingGroup/epicscorelibs_pcas@main",
+    'epicscorelibs_pcas @ https://github.com/ISISComputingGroup/epicscorelibs_pcas/releases/download/v0.0.1/epicscorelibs_pcas-0.0.1a0-cp311-cp311-win_amd64.whl ; python_version == "3.11"',
 ]
 
 dist = setup(


### PR DESCRIPTION
longer term it would be best to build `epicscorelibs_pcas` automatically against recent pythons on ci and upload to pypi so this all "just works", but this fixes a more immediate build issue with very recent VSs which the build server has.

Documented at https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Dependency-Updates#epicscorelibs_pcas